### PR TITLE
feat: add undo and redo buttons to editor toolbars and header

### DIFF
--- a/components/editor/EditorLayout.tsx
+++ b/components/editor/EditorLayout.tsx
@@ -41,6 +41,8 @@ import {
   PlusCircle,
   Trash2,
   Sparkles,
+  Undo2,
+  Redo2,
 } from "lucide-react";
 import { CollaboratorAvatars } from "@/components/editor/CollaboratorAvatars";
 import { PDFViewer } from "@/components/editor/PDFViewer";
@@ -718,6 +720,22 @@ export function EditorLayout({
         lastSelectionRef.current = lineRange;
         toast.info(`Selected line ${pos.lineNumber}`);
       }
+    }
+  };
+
+  const handleUndo = () => {
+    if (editorRef.current) {
+      editorRef.current.focus();
+      editorRef.current.trigger("toolbar", "undo", null);
+      toast.info("Undo");
+    }
+  };
+
+  const handleRedo = () => {
+    if (editorRef.current) {
+      editorRef.current.focus();
+      editorRef.current.trigger("toolbar", "redo", null);
+      toast.info("Redo");
     }
   };
 
@@ -1770,6 +1788,28 @@ export function EditorLayout({
             <Button
               variant="outline"
               size="sm"
+              onClick={handleUndo}
+              className="h-8 px-2 bg-zinc-900 hover:bg-zinc-800 border-zinc-800 text-zinc-300 hover:text-white text-xs font-mono flex items-center gap-1 cursor-pointer"
+              title="Undo (Ctrl+Z / Cmd+Z)"
+            >
+              <Undo2 className="w-3.5 h-3.5 text-amber-400" />
+              <span className="hidden lg:inline">Undo</span>
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRedo}
+              className="h-8 px-2 bg-zinc-900 hover:bg-zinc-800 border-zinc-800 text-zinc-300 hover:text-white text-xs font-mono flex items-center gap-1 cursor-pointer"
+              title="Redo (Ctrl+Y / Cmd+Shift+Z)"
+            >
+              <Redo2 className="w-3.5 h-3.5 text-orange-400" />
+              <span className="hidden lg:inline">Redo</span>
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
               onClick={() => saveDocument(code, true)}
               className="h-8 px-2.5 bg-zinc-900 hover:bg-zinc-800 border-zinc-800 text-zinc-300 hover:text-white text-xs font-mono flex items-center gap-1.5 cursor-pointer"
               title="Save Document (Ctrl+S)"
@@ -1837,6 +1877,24 @@ export function EditorLayout({
                 >
                   <ClipboardPaste className="w-3 h-3 text-emerald-400" />
                   <span>Paste</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={handleUndo}
+                  className="px-2 py-0.5 rounded bg-amber-500/20 hover:bg-amber-500/30 text-amber-300 border border-amber-500/40 shrink-0 font-semibold flex items-center gap-1 transition-colors"
+                  title="Undo last change (Ctrl+Z / Cmd+Z)"
+                >
+                  <Undo2 className="w-3 h-3 text-amber-400" />
+                  <span>Undo</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRedo}
+                  className="px-2 py-0.5 rounded bg-orange-500/20 hover:bg-orange-500/30 text-orange-300 border border-orange-500/40 shrink-0 font-semibold flex items-center gap-1 transition-colors"
+                  title="Redo change (Ctrl+Y / Cmd+Shift+Z)"
+                >
+                  <Redo2 className="w-3 h-3 text-orange-400" />
+                  <span>Redo</span>
                 </button>
                 <span className="text-[10px] text-muted-foreground uppercase font-semibold shrink-0">Quick TeX:</span>
                 {quickSymbols.map((sym) => (
@@ -2282,6 +2340,24 @@ export function EditorLayout({
                 >
                   <ClipboardPaste className="w-3.5 h-3.5 text-emerald-400" />
                   <span>Paste</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={handleUndo}
+                  className="px-2 py-1 rounded bg-amber-500/20 text-amber-300 border border-amber-500/40 shrink-0 text-xs font-semibold flex items-center gap-1"
+                  title="Undo (Ctrl+Z)"
+                >
+                  <Undo2 className="w-3.5 h-3.5 text-amber-400" />
+                  <span>Undo</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRedo}
+                  className="px-2 py-1 rounded bg-orange-500/20 text-orange-300 border border-orange-500/40 shrink-0 text-xs font-semibold flex items-center gap-1"
+                  title="Redo (Ctrl+Y)"
+                >
+                  <Redo2 className="w-3.5 h-3.5 text-orange-400" />
+                  <span>Redo</span>
                 </button>
                 {quickSymbols.map((sym) => (
                   <button


### PR DESCRIPTION
This pull request adds Undo and Redo functionality to the editor interface, making it easier for users to revert or reapply changes. The update introduces new buttons for Undo and Redo in multiple toolbar and quick action areas, and wires them up to the editor's command system.

**Editor functionality enhancements:**

* Added `Undo2` and `Redo2` icons from `lucide-react` for use in the new Undo/Redo buttons.
* Implemented `handleUndo` and `handleRedo` functions that trigger the editor's undo and redo actions, and display a toast notification for each.

**UI improvements:**

* Added Undo and Redo buttons to the main editor toolbar, with keyboard shortcut hints in their tooltips.
* Added Undo and Redo buttons to the quick actions bar below the editor, styled for visibility and accessibility.
* Added Undo and Redo buttons to the mobile/compact quick actions area, ensuring functionality is available on all device sizes.