### PR TITLE
Fix model viewer issue

### DIFF
--- a/components/editor/EditorLayout.tsx
+++ b/components/editor/EditorLayout.tsx
@@ -240,7 +240,7 @@ export function EditorLayout({
   const lastPositionRef = useRef<any>(null);
   const [attachedFile, setAttachedFile] = useState<{ filename: string; content: string; file_type: string } | null>(null);
   const [isFileAnalyzerOpen, setIsFileAnalyzerOpen] = useState<boolean>(false);
-  const [activeModelName, setActiveModelName] = useState<string>("auto:smart");
+  const [activeModelName, setActiveModelName] = useState<string>("gemini-3.7-flash");
   const [fallbackModelNotice, setFallbackModelNotice] = useState<string | null>(null);
   const [agentProgressSteps, setAgentProgressSteps] = useState<{ step: string; message: string; icon: string }[]>([]);
   const [filesRefreshTrigger, setFilesRefreshTrigger] = useState<number>(0);
@@ -515,42 +515,47 @@ export function EditorLayout({
   }, [activeMobileTab]);
 
   // ─── Model Selector State ────────────────────────────────────────────────
-  const [availableModels, setAvailableModels] = useState<ProviderGroup[]>([]);
+  const [availableModels, setAvailableModels] = useState<ProviderGroup[]>([
+    {
+      name: "Gemini Web2API",
+      models: [
+        { id: "gemini-3.7-flash", label: "Gemini 3.7 Flash", default: true },
+        { id: "gemini-3.6-flash", label: "Gemini 3.6 Flash", default: false },
+        { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", default: false },
+        { id: "gemini-3.5-flash-thinking", label: "Gemini 3.5 Flash Thinking", default: false },
+        { id: "gemini-3.5-flash-thinking-lite", label: "Gemini 3.5 Flash Thinking Lite", default: false },
+      ],
+    },
+    {
+      name: "FreeLLM API",
+      models: [
+        { id: "auto:smart", label: "FreeLLM Auto Smart", default: false },
+        { id: "auto", label: "FreeLLM Auto Router", default: false },
+        { id: "auto:fast", label: "FreeLLM Auto Fast", default: false },
+        { id: "openai/gpt-oss-120b", label: "GPT-OSS-120B", default: false },
+      ],
+    },
+  ]);
 
   // Fetch available models via protected tRPC on mount
   useEffect(() => {
     const fetchModels = async () => {
       try {
         const data = await trpcClient.ai.models.query();
-        if (data && Array.isArray(data) && data.length > 0) {
+        if (data?.providers && Array.isArray(data.providers) && data.providers.length > 0) {
+          setAvailableModels(data.providers);
+          if (data.defaultModel) {
+            setActiveModelName(data.defaultModel);
+          }
+        } else if (Array.isArray(data) && data.length > 0) {
           setAvailableModels(data);
-          const firstDefault = data.flatMap((g) => g.models).find((m) => m.default)?.id;
+          const firstDefault = data.flatMap((g: any) => g.models).find((m: any) => m.default)?.id;
           if (firstDefault) {
             setActiveModelName(firstDefault);
           }
         }
       } catch (err) {
         console.warn("Failed to fetch models via tRPC:", err);
-        // Fallback: hardcode defaults so selector still works
-        setAvailableModels([
-          {
-            name: "Gemini Web2API", models: [
-              { id: "gemini-3.7-flash", label: "Gemini 3.7 Flash (Web2API)", default: true },
-              { id: "gemini-3.6-flash", label: "Gemini 3.6 Flash" },
-              { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
-              { id: "gemini-3.5-flash-thinking", label: "Gemini 3.5 Flash Thinking" },
-              { id: "gemini-3.5-flash-thinking-lite", label: "Gemini 3.5 Flash Thinking Lite" },
-            ]
-          },
-          {
-            name: "FreeLLM API", models: [
-              { id: "auto:smart", label: "FreeLLM Auto Smart" },
-              { id: "auto", label: "FreeLLM Auto Router" },
-              { id: "auto:fast", label: "FreeLLM Auto Fast" },
-              { id: "openai/gpt-oss-120b", label: "GPT-OSS-120B" },
-            ]
-          },
-        ]);
       }
     };
     fetchModels();

--- a/components/editor/ModelSelector.tsx
+++ b/components/editor/ModelSelector.tsx
@@ -86,7 +86,8 @@ export function ModelSelector({
 
   // Get active model label
   const activeLabel = useMemo(() => {
-    if (activeModelName === "auto:smart") return "Auto (Smart)";
+    if (activeModelName === "gemini-3.7-flash") return "Gemini 3.7 Flash";
+    if (activeModelName === "auto:smart") return "FreeLLM Auto Smart";
     for (const group of availableModels) {
       const match = group.models.find((m) => m.id === activeModelName);
       if (match) return match.label;

--- a/trpc/routers/ai.ts
+++ b/trpc/routers/ai.ts
@@ -19,21 +19,58 @@ export interface ProviderGroup {
   models: ModelOption[];
 }
 
+const DEFAULT_PROVIDER_GROUPS: ProviderGroup[] = [
+  {
+    name: "Gemini Web2API",
+    models: [
+      { id: "gemini-3.7-flash", label: "Gemini 3.7 Flash", default: true },
+      { id: "gemini-3.6-flash", label: "Gemini 3.6 Flash", default: false },
+      { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", default: false },
+      { id: "gemini-3.5-flash-thinking", label: "Gemini 3.5 Flash Thinking", default: false },
+      { id: "gemini-3.5-flash-thinking-lite", label: "Gemini 3.5 Flash Thinking Lite", default: false },
+    ],
+  },
+  {
+    name: "FreeLLM API",
+    models: [
+      { id: "auto:smart", label: "FreeLLM Auto Smart", default: false },
+      { id: "auto", label: "FreeLLM Auto Router", default: false },
+      { id: "auto:fast", label: "FreeLLM Auto Fast", default: false },
+      { id: "openai/gpt-oss-120b", label: "GPT-OSS-120B", default: false },
+    ],
+  },
+];
+
 export const aiRouter = router({
   models: protectedProcedure.query(async () => {
     try {
       const res = await fetch(`${BACKEND_URL}/api/models`, {
         cache: "no-store",
       });
-      if (!res.ok) {
-        throw new Error(`Failed to fetch models: ${res.statusText}`);
+      if (res.ok) {
+        const data = await res.json();
+        const providers: ProviderGroup[] = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.providers)
+          ? data.providers
+          : DEFAULT_PROVIDER_GROUPS;
+
+        const defaultModel: string =
+          data?.default_model || "gemini-3.7-flash";
+
+        return {
+          providers: providers.length > 0 ? providers : DEFAULT_PROVIDER_GROUPS,
+          defaultModel,
+        };
       }
-      const data: ProviderGroup[] = await res.json();
-      return data;
     } catch (err: any) {
       console.error("Error fetching models from backend via tRPC:", err);
-      return [];
     }
+
+    return {
+      providers: DEFAULT_PROVIDER_GROUPS,
+      defaultModel: "gemini-3.7-flash",
+    };
   }),
 
   analyzeFile: protectedProcedure


### PR DESCRIPTION
This pull request updates the default and fallback model selection logic for the editor, ensuring a smoother experience when fetching available AI models and providing more robust defaults. The changes improve how models are selected and displayed, and ensure consistent fallback behavior if the backend is unavailable.

**Model selection and fallback improvements:**

* The default active model is now set to `"gemini-3.7-flash"` instead of `"auto:smart"` in the editor state.
* The initial list of `availableModels` in `EditorLayout.tsx` is now hardcoded to include both "Gemini Web2API" and "FreeLLM API" groups, with their respective models and default flags. This ensures the model selector works even if fetching from the backend fails.
* The logic for fetching models via tRPC was updated to expect a `{ providers, defaultModel }` object, and to set both the available models and the active model accordingly. If the backend fails or returns no providers, the hardcoded defaults are used. [[1]](diffhunk://#diff-c3c0bf9692506503cedf7796a54c288316c2ece8617cde8327294eadeaa4ae26L518-L553) [[2]](diffhunk://#diff-24f8e97e274bf01041a3f25b461725aeb8966d59a5ca9520914a66ce61e98e03R22-R73)

**UI consistency improvements:**

* The label for the active model in the `ModelSelector` component now correctly displays "Gemini 3.7 Flash" when that model is selected, and "FreeLLM Auto Smart" for the `"auto:smart"` model.

**Backend and API changes:**

* The tRPC router for AI models (`aiRouter`) now provides a consistent response structure with `providers` and `defaultModel`, always falling back to the hardcoded defaults if the backend fetch fails. This ensures UI stability and consistent model options.